### PR TITLE
Update driver.py to use inputs

### DIFF
--- a/naturf/driver.py
+++ b/naturf/driver.py
@@ -64,7 +64,7 @@ class Model:
         # instantiate driver with function definitions & adapters
         self.dr = (
             driver.Builder()
-            .with_config(self.inputs)
+            .with_config({})
             .with_modules(nodes, output)
             .with_adapters(*hamilton_adapters)
             .build()
@@ -74,7 +74,7 @@ class Model:
         """Run the driver."""
 
         # generate initial data frame
-        df = self.dr.execute(self.outputs)
+        df = self.dr.execute(self.outputs, inputs=self.inputs)
 
         return df
 
@@ -82,7 +82,7 @@ class Model:
         """Show the DAG. Return the graph object for the given inputs to execute."""
 
         return self.dr.visualize_execution(
-            final_vars=self.outputs, output_file_path=output_file_path, render_kwargs={"view": view}
+            final_vars=self.outputs, inputs=self.inputs, output_file_path=output_file_path, render_kwargs={"view": view}
         )
 
     def list_parameters(self):


### PR DESCRIPTION
Inputs can be passed in as configuration, but really they should be passed in as inputs -- that way visualization doesn't interpret them as configuration.

I assume there is no `@config.when` in the code -- is that right?