### PR TITLE
update base docker image to sanctioned msdlive base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build Stage
-FROM quay.io/jupyter/minimal-notebook as builder
+FROM ghcr.io/msd-live/jupyter/python-notebook:latest as builder
 
 USER root
 
@@ -20,7 +20,7 @@ RUN pip install --upgrade pip
 RUN pip install naturf
 
 # Stage 2: Final Stage
-FROM quay.io/jupyter/minimal-notebook
+FROM ghcr.io/msd-live/jupyter/python-notebook:latest
 
 USER root
 


### PR DESCRIPTION
Updates the base docker image to an officially sanctioned msdlive base docker image.

I wasn't totally sure how to test this, but did confirm the image builds without error. @levisweetbreu in light of @erexer 's leave, are you able to review/test?