### PR TITLE
Add support for MultiPolygon geometry and parallelization

### DIFF
--- a/naturf/nodes.py
+++ b/naturf/nodes.py
@@ -11,7 +11,7 @@ from shapely.geometry import Polygon, MultiPolygon
 from shapely.geometry.base import BaseGeometry
 from joblib import Parallel, delayed
 
-from .config import Settings 
+from .config import Settings
 from .utils import log_execution_time
 
 
@@ -215,20 +215,23 @@ def building_plan_area(
     target_id_col = "building_id_target"
     target_buffer_col = "building_buffered_target"
     neighbor_geom_col = "building_geometry_neighbor"
-    area_col = 'intersection_area' # temporary column for calculated area
+    area_col = "intersection_area"  # temporary column for calculated area
 
     # Input validation
     required_columns = [target_id_col, target_buffer_col, neighbor_geom_col]
-    missing_cols = [col for col in required_columns if col not in buildings_intersecting_plan_area.columns]
+    missing_cols = [
+        col for col in required_columns if col not in buildings_intersecting_plan_area.columns
+    ]
     if missing_cols:
         raise ValueError(f"Missing required columns: {', '.join(missing_cols)}")
-        
-    if not hasattr(buildings_intersecting_plan_area[target_buffer_col], 'geom_type') or \
-       not hasattr(buildings_intersecting_plan_area[neighbor_geom_col], 'geom_type'):
+
+    if not hasattr(buildings_intersecting_plan_area[target_buffer_col], "geom_type") or not hasattr(
+        buildings_intersecting_plan_area[neighbor_geom_col], "geom_type"
+    ):
         raise TypeError(f"Columns '{target_buffer_col}' or '{neighbor_geom_col}' not GeoSeries.")
 
     # Work on a copy or directly on the input depending on whether modification is okay
-    gdf = buildings_intersecting_plan_area # Use directly for efficiency if input not needed later
+    gdf = buildings_intersecting_plan_area  # Use directly for efficiency if input not needed later
 
     # Calculate intersection geometry for each row
     intersection_geoms = gdf[target_buffer_col].intersection(gdf[neighbor_geom_col])
@@ -574,24 +577,23 @@ def frontal_length(
 
     # Input validation
     required_columns = [grouping_col, col_north, col_east, col_south, col_west]
-    missing_cols = [col for col in required_columns if col not in buildings_intersecting_plan_area.columns]
+    missing_cols = [
+        col for col in required_columns if col not in buildings_intersecting_plan_area.columns
+    ]
     if missing_cols:
-        raise ValueError(f"Missing required columns in input GeoDataFrame: {', '.join(missing_cols)}")
+        raise ValueError(
+            f"Missing required columns in input GeoDataFrame: {', '.join(missing_cols)}"
+        )
 
     # Define the aggregation operations
     # We want to sum each of the directional wall length columns
-    aggregations = {
-        col_north: 'sum',
-        col_east: 'sum',
-        col_south: 'sum',
-        col_west: 'sum'
-    }
+    aggregations = {col_north: "sum", col_east: "sum", col_south: "sum", col_west: "sum"}
 
     # Perform the groupby and aggregation
     # Group by the target building ID, then apply the sum aggregation
-    frontal_lengths_grouped = buildings_intersecting_plan_area.groupby(
-        grouping_col
-    ).agg(aggregations)
+    frontal_lengths_grouped = buildings_intersecting_plan_area.groupby(grouping_col).agg(
+        aggregations
+    )
 
     # Rename the resulting columns to the final desired names
     rename_map = {
@@ -1134,37 +1136,46 @@ def _get_polygon_segment_properties(polygon: Polygon) -> tuple[list, list, list]
     """
     Calculate the angles, directions, and lengths of each segment of a polygon's exterior.
 
-    This function processes the exterior coordinates of a given polygon to determine the 
-    angle in degrees, cardinal direction, and length of each segment. The direction is 
+    This function processes the exterior coordinates of a given polygon to determine the
+    angle in degrees, cardinal direction, and length of each segment. The direction is
     determined based on predefined degree ranges specified in the Settings.
 
     :param polygon: A Shapely Polygon object whose exterior segments are to be analyzed.
     :type polygon: Polygon
 
-    :return: A tuple containing three lists: angles (in degrees), directions (as strings), 
+    :return: A tuple containing three lists: angles (in degrees), directions (as strings),
              and lengths (as floats) for each segment of the polygon's exterior.
     :rtype: tuple[list, list, list]
     """
     angles, directions, lengths = [], [], []
     coords = list(polygon.exterior.coords)
 
-    if len(coords) < 2: 
+    if len(coords) < 2:
         return angles, directions, lengths
 
     for i in range(len(coords) - 1):
 
-        x1, y1 = coords[i]; x2, y2 = coords[i+1]
-        if x1 == x2 and y1 == y2: continue
+        x1, y1 = coords[i]
+        x2, y2 = coords[i + 1]
+        if x1 == x2 and y1 == y2:
+            continue
         angle_rad = np.arctan2(y2 - y1, x2 - x1)
         angle_deg = np.degrees(angle_rad)
-        length = np.sqrt((x2 - x1)**2 + (y2 - y1)**2)
+        length = np.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
 
         # Determine direction
-        if Settings.NORTHEAST_DEGREES <= angle_deg < Settings.NORTHWEST_DEGREES: direction = Settings.WEST
-        elif Settings.SOUTHEAST_DEGREES_ARCTAN <= angle_deg < Settings.NORTHEAST_DEGREES: direction = Settings.NORTH
-        elif Settings.SOUTHWEST_DEGREES_ARCTAN <= angle_deg < Settings.SOUTHEAST_DEGREES_ARCTAN: direction = Settings.EAST
-        else: direction = Settings.SOUTH
-        angles.append(angle_deg); directions.append(direction); lengths.append(length)
+        if Settings.NORTHEAST_DEGREES <= angle_deg < Settings.NORTHWEST_DEGREES:
+            direction = Settings.WEST
+        elif Settings.SOUTHEAST_DEGREES_ARCTAN <= angle_deg < Settings.NORTHEAST_DEGREES:
+            direction = Settings.NORTH
+        elif Settings.SOUTHWEST_DEGREES_ARCTAN <= angle_deg < Settings.SOUTHEAST_DEGREES_ARCTAN:
+            direction = Settings.EAST
+        else:
+            direction = Settings.SOUTH
+
+        angles.append(angle_deg)
+        directions.append(direction)
+        lengths.append(length)
 
     return angles, directions, lengths
 
@@ -1173,14 +1184,14 @@ def _process_single_geometry(geom: BaseGeometry | None) -> dict:
     """
     Process a single geometry object to extract wall angles, directions, and lengths.
 
-    This function handles both Polygon and MultiPolygon geometries, extracting the 
-    angles, cardinal directions, and lengths of each segment of the geometry's exterior. 
+    This function handles both Polygon and MultiPolygon geometries, extracting the
+    angles, cardinal directions, and lengths of each segment of the geometry's exterior.
     It is designed to be used with parallel processing via joblib.Parallel.
 
     :param geom: A geometry object which can be a Polygon, MultiPolygon, or None.
     :type geom: BaseGeometry or None
 
-    :return: A dictionary containing lists of wall angles, directions, and lengths. 
+    :return: A dictionary containing lists of wall angles, directions, and lengths.
              If the geometry is None or invalid, the lists will be empty.
     :rtype: dict
     """
@@ -1191,7 +1202,7 @@ def _process_single_geometry(geom: BaseGeometry | None) -> dict:
         return {
             Settings.WALL_ANGLE: building_angles,
             Settings.WALL_DIRECTION: building_directions,
-            Settings.WALL_LENGTH: building_lengths
+            Settings.WALL_LENGTH: building_lengths,
         }
 
     # Process Polygon or MultiPolygon
@@ -1212,7 +1223,7 @@ def _process_single_geometry(geom: BaseGeometry | None) -> dict:
     return {
         Settings.WALL_ANGLE: building_angles,
         Settings.WALL_DIRECTION: building_directions,
-        Settings.WALL_LENGTH: building_lengths
+        Settings.WALL_LENGTH: building_lengths,
     }
 
 
@@ -1221,18 +1232,18 @@ def wall_angle_direction_length(building_geometry: pd.Series, n_jobs: int = -1) 
     """
     Computes the wall angle, direction, and length for each building in a given GeoPandas GeoSeries.
 
-    This function processes each building's geometry to determine the angles, cardinal directions, 
-    and lengths of its walls. It utilizes parallel processing to enhance performance, especially 
+    This function processes each building's geometry to determine the angles, cardinal directions,
+    and lengths of its walls. It utilizes parallel processing to enhance performance, especially
     with large datasets.
 
     :param building_geometry: A series containing the geometries of buildings.
     :type building_geometry: pd.Series
 
-    :param n_jobs: The number of CPU cores to use for parallel processing. Defaults to -1, which 
+    :param n_jobs: The number of CPU cores to use for parallel processing. Defaults to -1, which
                    uses all available cores. If set to a value less than 1, it defaults to 1 core.
     :type n_jobs: int
 
-    :return: A DataFrame where each row corresponds to a building and contains lists of wall angles, 
+    :return: A DataFrame where each row corresponds to a building and contains lists of wall angles,
              directions, and lengths.
     :rtype: pd.DataFrame
 
@@ -1248,9 +1259,9 @@ def wall_angle_direction_length(building_geometry: pd.Series, n_jobs: int = -1) 
     if n_jobs == -1:
         num_cores = multiprocessing.cpu_count()
     elif n_jobs < 1:
-         num_cores = 1 # Ensure at least 1 core
+        num_cores = 1  # Ensure at least 1 core
     else:
-         num_cores = min(n_jobs, multiprocessing.cpu_count())
+        num_cores = min(n_jobs, multiprocessing.cpu_count())
 
     results_list = Parallel(n_jobs=num_cores)(
         delayed(_process_single_geometry)(geom) for geom in building_geometry

--- a/naturf/nodes.py
+++ b/naturf/nodes.py
@@ -1,5 +1,6 @@
 import math
-import multiprocessing 
+import multiprocessing
+import logging
 
 import geopandas as gpd
 import numpy as np
@@ -10,9 +11,15 @@ from shapely.geometry import Polygon, MultiPolygon
 from shapely.geometry.base import BaseGeometry
 from joblib import Parallel, delayed
 
-from .config import Settings
+from .config import Settings 
+from .utils import log_execution_time
 
 
+# Get a logger for this module (can be used for warnings)
+logger = logging.getLogger(__name__)
+
+
+@log_execution_time
 def area_weighted_mean_of_building_heights(
     buildings_intersecting_plan_area: gpd.GeoDataFrame,
 ) -> pd.Series:
@@ -44,6 +51,7 @@ def area_weighted_mean_of_building_heights(
     return pd.Series(df.values)
 
 
+@log_execution_time
 def average_distance_between_buildings(distance_between_buildings: pd.Series) -> pd.Series:
     """Calculate the average distance from the target building to all neighboring buildings.
 
@@ -70,6 +78,7 @@ def average_distance_between_buildings(distance_between_buildings: pd.Series) ->
     return df[Settings.AVERAGE_DISTANCE_BETWEEN_BUILDINGS]
 
 
+@log_execution_time
 def building_area(building_geometry: pd.Series) -> pd.Series:
     """Calculate the area of the building geometry.
 
@@ -83,6 +92,7 @@ def building_area(building_geometry: pd.Series) -> pd.Series:
     return building_geometry.area
 
 
+@log_execution_time
 def buildings_intersecting_plan_area(
     building_id: pd.Series,
     building_height: pd.Series,
@@ -179,6 +189,7 @@ def buildings_intersecting_plan_area(
     return gpd.GeoDataFrame(xdf).set_geometry(Settings.GEOMETRY_FIELD)
 
 
+@log_execution_time
 def building_plan_area(
     buildings_intersecting_plan_area: gpd.GeoDataFrame,
     join_predicate: str = "intersection",
@@ -235,6 +246,7 @@ def building_plan_area(
     return pd.Series(building_plan_area)
 
 
+@log_execution_time
 def building_surface_area(
     wall_length: pd.DataFrame, building_height: pd.Series, building_area: pd.Series
 ) -> pd.Series:
@@ -258,6 +270,7 @@ def building_surface_area(
     return wall_area + building_area
 
 
+@log_execution_time
 def building_surface_area_to_plan_area_ratio(
     building_surface_area: pd.Series, total_plan_area: pd.Series
 ) -> pd.Series:
@@ -276,6 +289,7 @@ def building_surface_area_to_plan_area_ratio(
     return building_surface_area / total_plan_area
 
 
+@log_execution_time
 def complete_aspect_ratio(
     building_surface_area: pd.Series, total_plan_area: pd.Series, building_plan_area: pd.Series
 ) -> pd.Series:
@@ -299,6 +313,7 @@ def complete_aspect_ratio(
     return (building_surface_area + exposed_ground) / total_plan_area
 
 
+@log_execution_time
 def distance_between_buildings(buildings_intersecting_plan_area: gpd.GeoDataFrame) -> pd.Series:
     """Calculate the distance between each building and its neighbor as defined in buildings_intersecting_plan_area.
 
@@ -316,6 +331,7 @@ def distance_between_buildings(buildings_intersecting_plan_area: gpd.GeoDataFram
     )
 
 
+@log_execution_time
 @extract_columns(*[Settings.ID_FIELD, Settings.HEIGHT_FIELD, Settings.GEOMETRY_FIELD])
 def filter_height_range(standardize_column_names_df: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     """Filter out any zero height buildings and reindex the data frame.  Extract the building_id,
@@ -338,6 +354,7 @@ def filter_height_range(standardize_column_names_df: gpd.GeoDataFrame) -> gpd.Ge
     ].reset_index(drop=True)
 
 
+@log_execution_time
 def frontal_area(frontal_length: pd.DataFrame, building_height: pd.Series) -> pd.DataFrame:
     """Calculate the frontal area for each building in a Pandas DataFrame in each cardinal direction.
 
@@ -362,6 +379,7 @@ def frontal_area(frontal_length: pd.DataFrame, building_height: pd.Series) -> pd
     return frontal_area
 
 
+@log_execution_time
 def frontal_area_density(
     frontal_length: pd.DataFrame, building_height: pd.Series, total_plan_area: pd.Series
 ) -> pd.DataFrame:
@@ -507,6 +525,7 @@ def frontal_area_density(
     )
 
 
+@log_execution_time
 def frontal_area_index(frontal_area: pd.DataFrame, total_plan_area: pd.Series) -> pd.DataFrame:
     """Calculate the frontal area index for each building in a Pandas DataFrame in each cardinal direction.
 
@@ -530,6 +549,7 @@ def frontal_area_index(frontal_area: pd.DataFrame, total_plan_area: pd.Series) -
     return frontal_area_index
 
 
+@log_execution_time
 def frontal_length(
     buildings_intersecting_plan_area: gpd.GeoDataFrame,
 ) -> pd.DataFrame:
@@ -591,6 +611,7 @@ def frontal_length(
     return frontal_lengths_final
 
 
+@log_execution_time
 def grimmond_oke_displacement_height(building_height: pd.Series) -> pd.Series:
     """Calculate the Grimmond & Oke displacement height for each building
 
@@ -604,6 +625,7 @@ def grimmond_oke_displacement_height(building_height: pd.Series) -> pd.Series:
     return building_height * Settings.DISPLACEMENT_HEIGHT_FACTOR
 
 
+@log_execution_time
 def grimmond_oke_roughness_length(building_height: pd.Series) -> pd.Series:
     """Calculate the Grimmond & Oke roughness length for each building
 
@@ -617,6 +639,7 @@ def grimmond_oke_roughness_length(building_height: pd.Series) -> pd.Series:
     return building_height * Settings.ROUGHNESS_LENGTH_FACTOR
 
 
+@log_execution_time
 def height_to_width_ratio(
     mean_building_height: pd.Series, average_distance_between_buildings: pd.Series
 ) -> pd.Series:
@@ -635,6 +658,7 @@ def height_to_width_ratio(
     return mean_building_height / average_distance_between_buildings
 
 
+@log_execution_time
 def input_shapefile_df(input_shapefile: str) -> gpd.GeoDataFrame:
     """Import shapefile to GeoDataFrame using only desired columns.
 
@@ -656,6 +680,7 @@ def input_shapefile_df(input_shapefile: str) -> gpd.GeoDataFrame:
     return gdf
 
 
+@log_execution_time
 def lot_area(
     buildings_intersecting_plan_area: gpd.GeoDataFrame, building_surface_area: pd.Series
 ) -> pd.Series:
@@ -682,6 +707,7 @@ def lot_area(
     return pd.Series(df.values)
 
 
+@log_execution_time
 def macdonald_displacement_height(
     building_height: pd.Series, plan_area_fraction: pd.Series
 ) -> pd.Series:
@@ -705,6 +731,7 @@ def macdonald_displacement_height(
     return right_side * building_height
 
 
+@log_execution_time
 def macdonald_roughness_length(
     building_height: pd.Series,
     macdonald_displacement_height: pd.Series,
@@ -758,6 +785,7 @@ def macdonald_roughness_length(
     return macdonald_roughness_length
 
 
+@log_execution_time
 def mean_building_height(buildings_intersecting_plan_area: gpd.GeoDataFrame) -> pd.Series:
     """Calculate the mean building height for all buildings within the target building's total plan area.
 
@@ -775,6 +803,7 @@ def mean_building_height(buildings_intersecting_plan_area: gpd.GeoDataFrame) -> 
     return pd.Series(df.values)
 
 
+@log_execution_time
 def plan_area_density(
     building_plan_area: pd.Series, building_height: pd.Series, total_plan_area: pd.Series
 ) -> pd.DataFrame:
@@ -817,6 +846,7 @@ def plan_area_density(
     return pd.DataFrame(plan_area_density, columns=columns_plan_area_density)
 
 
+@log_execution_time
 def plan_area_fraction(building_plan_area: pd.Series, total_plan_area: pd.Series) -> pd.Series:
     """Calculate the plan area fraction for each building in a Pandas Series. Plan area fraction is the building plan area at ground level
     for each building divided by the total plan area.
@@ -833,6 +863,7 @@ def plan_area_fraction(building_plan_area: pd.Series, total_plan_area: pd.Series
     return building_plan_area / total_plan_area
 
 
+@log_execution_time
 def raupach_displacement_height(
     building_height: pd.Series, frontal_area_index: pd.DataFrame
 ) -> pd.DataFrame:
@@ -868,6 +899,7 @@ def raupach_displacement_height(
     return raupach_displacement_height
 
 
+@log_execution_time
 def raupach_roughness_length(
     building_height: pd.Series,
     frontal_area_index: pd.DataFrame,
@@ -922,6 +954,7 @@ def raupach_roughness_length(
     return raupach_roughness_length
 
 
+@log_execution_time
 def rooftop_area_density(plan_area_density: pd.DataFrame) -> pd.DataFrame:
     """Calculate the rooftop area density for each building in a Pandas DataFrame. Rooftop area density is the roof area
     of all buildings within the total plan area  at a specified height increment divided by the total plan area. naturf
@@ -942,6 +975,7 @@ def rooftop_area_density(plan_area_density: pd.DataFrame) -> pd.DataFrame:
     return pd.DataFrame(plan_area_density.values.tolist(), columns=columns_rooftop_area_density)
 
 
+@log_execution_time
 def sky_view_factor(
     building_height: pd.Series, average_distance_between_buildings: pd.Series
 ) -> pd.Series:
@@ -960,6 +994,7 @@ def sky_view_factor(
     return np.cos(np.arctan(building_height / (0.5 * average_distance_between_buildings)))
 
 
+@log_execution_time
 def standard_deviation_of_building_heights(
     buildings_intersecting_plan_area: gpd.GeoDataFrame,
 ) -> pd.Series:
@@ -983,6 +1018,7 @@ def standard_deviation_of_building_heights(
     return pd.Series(df.values)
 
 
+@log_execution_time
 def standardize_column_names_df(input_shapefile_df: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     """Standardize field names so use throughout code will be consistent throughout.
 
@@ -1006,6 +1042,7 @@ def standardize_column_names_df(input_shapefile_df: gpd.GeoDataFrame) -> gpd.Geo
     return input_shapefile_df.set_geometry(Settings.GEOMETRY_FIELD)
 
 
+@log_execution_time
 def target_crs(input_shapefile_df: gpd.GeoDataFrame) -> CRS:
     """Extract coordinate reference system from geometry.
 
@@ -1019,6 +1056,7 @@ def target_crs(input_shapefile_df: gpd.GeoDataFrame) -> CRS:
     return input_shapefile_df.set_geometry(Settings.GEOMETRY_FIELD).crs
 
 
+@log_execution_time
 def total_plan_area(total_plan_area_geometry: gpd.GeoSeries) -> pd.Series:
     """Calculate the total plan area for each building in a GeoPandas GeoSeries.
 
@@ -1032,6 +1070,7 @@ def total_plan_area(total_plan_area_geometry: gpd.GeoSeries) -> pd.Series:
     return total_plan_area_geometry.area
 
 
+@log_execution_time
 def total_plan_area_geometry(
     building_geometry: pd.Series, radius: int = Settings.RADIUS, cap_style: int = Settings.CAP_STYLE
 ) -> gpd.GeoSeries:
@@ -1056,6 +1095,7 @@ def total_plan_area_geometry(
     return building_geometry.buffer(distance=radius, cap_style=cap_style)
 
 
+@log_execution_time
 def vertical_distribution_of_building_heights(building_height: pd.Series) -> pd.DataFrame:
     """Represent the location of buildings at 5m increments from ground level to 75m unless otherwise specified. If is within a
     given height bin, it will be given a 1 and it will be given a 0 otherwise."
@@ -1179,6 +1219,7 @@ def _process_single_geometry(geom: BaseGeometry | None) -> dict:
     }
 
 
+@log_execution_time
 def wall_angle_direction_length(building_geometry: pd.Series, n_jobs: int = -1) -> pd.DataFrame:
     """
     Computes the wall angle, direction, and length for each building in a given GeoPandas GeoSeries.
@@ -1223,6 +1264,7 @@ def wall_angle_direction_length(building_geometry: pd.Series, n_jobs: int = -1) 
     return output_df
 
 
+@log_execution_time
 def wall_length(wall_angle_direction_length: pd.DataFrame) -> pd.DataFrame:
     """Calculate the wall length for each building in a GeoPandas GeoSeries.
 

--- a/naturf/nodes.py
+++ b/naturf/nodes.py
@@ -1,9 +1,14 @@
-import geopandas as gpd
 import math
+import multiprocessing 
+
+import geopandas as gpd
 import numpy as np
 import pandas as pd
 from pyproj.crs import CRS
 from hamilton.function_modifiers import extract_columns
+from shapely.geometry import Polygon, MultiPolygon
+from shapely.geometry.base import BaseGeometry
+from joblib import Parallel, delayed
 
 from .config import Settings
 
@@ -1084,72 +1089,137 @@ def vertical_distribution_of_building_heights(building_height: pd.Series) -> pd.
     )
 
 
-def wall_angle_direction_length(building_geometry: pd.Series) -> pd.DataFrame:
-    """Calculate the wall angle, direction, and length for each building in a GeoPandas GeoSeries.
-
-    :param geometry:                    Geometry for a series of buildings.
-    :type geometry:                     pd.Series
-
-    :return:                            Pandas DataFrame with wall angle, direction, and length for each building.
-
+def _get_polygon_segment_properties(polygon: Polygon) -> tuple[list, list, list]:
     """
+    Calculate the angles, directions, and lengths of each segment of a polygon's exterior.
 
-    wall_angle, wall_direction, wall_length = (
-        [[] for x in range(building_geometry.size)],
-        [[] for x in range(building_geometry.size)],
-        [[] for x in range(building_geometry.size)],
+    This function processes the exterior coordinates of a given polygon to determine the 
+    angle in degrees, cardinal direction, and length of each segment. The direction is 
+    determined based on predefined degree ranges specified in the Settings.
+
+    :param polygon: A Shapely Polygon object whose exterior segments are to be analyzed.
+    :type polygon: Polygon
+
+    :return: A tuple containing three lists: angles (in degrees), directions (as strings), 
+             and lengths (as floats) for each segment of the polygon's exterior.
+    :rtype: tuple[list, list, list]
+    """
+    angles, directions, lengths = [], [], []
+    coords = list(polygon.exterior.coords)
+    if len(coords) < 2: return angles, directions, lengths
+    for i in range(len(coords) - 1):
+        x1, y1 = coords[i]; x2, y2 = coords[i+1]
+        if x1 == x2 and y1 == y2: continue
+        angle_rad = np.arctan2(y2 - y1, x2 - x1)
+        angle_deg = np.degrees(angle_rad)
+        length = np.sqrt((x2 - x1)**2 + (y2 - y1)**2)
+        # Determine direction based on Settings
+        if Settings.NORTHEAST_DEGREES <= angle_deg < Settings.NORTHWEST_DEGREES: direction = Settings.WEST
+        elif Settings.SOUTHEAST_DEGREES_ARCTAN <= angle_deg < Settings.NORTHEAST_DEGREES: direction = Settings.NORTH
+        elif Settings.SOUTHWEST_DEGREES_ARCTAN <= angle_deg < Settings.SOUTHEAST_DEGREES_ARCTAN: direction = Settings.EAST
+        else: direction = Settings.SOUTH
+        angles.append(angle_deg); directions.append(direction); lengths.append(length)
+    return angles, directions, lengths
+
+
+def _process_single_geometry(geom: BaseGeometry | None) -> dict:
+    """
+    Process a single geometry object to extract wall angles, directions, and lengths.
+
+    This function handles both Polygon and MultiPolygon geometries, extracting the 
+    angles, cardinal directions, and lengths of each segment of the geometry's exterior. 
+    It is designed to be used with parallel processing via joblib.Parallel.
+
+    :param geom: A geometry object which can be a Polygon, MultiPolygon, or None.
+    :type geom: BaseGeometry or None
+
+    :return: A dictionary containing lists of wall angles, directions, and lengths. 
+             If the geometry is None or invalid, the lists will be empty.
+    :rtype: dict
+    """
+    building_angles, building_directions, building_lengths = [], [], []
+
+    # Handle invalid/empty cases first
+    if geom is None or not isinstance(geom, BaseGeometry) or geom.is_empty:
+        return {
+            Settings.WALL_ANGLE: building_angles,
+            Settings.WALL_DIRECTION: building_directions,
+            Settings.WALL_LENGTH: building_lengths
+        }
+
+    # Process Polygon or MultiPolygon
+    if isinstance(geom, Polygon):
+        angles, directions, lengths = _get_polygon_segment_properties(geom)
+        building_angles.extend(angles)
+        building_directions.extend(directions)
+        building_lengths.extend(lengths)
+
+    elif isinstance(geom, MultiPolygon):
+        for poly in geom.geoms:
+            if isinstance(poly, Polygon):
+                angles, directions, lengths = _get_polygon_segment_properties(poly)
+                building_angles.extend(angles)
+                building_directions.extend(directions)
+                building_lengths.extend(lengths)
+    # else: handle other types if necessary, currently ignored
+
+    # Return the dictionary of results for this geometry
+    return {
+        Settings.WALL_ANGLE: building_angles,
+        Settings.WALL_DIRECTION: building_directions,
+        Settings.WALL_LENGTH: building_lengths
+    }
+
+
+def wall_angle_direction_length(building_geometry: pd.Series, n_jobs: int = -1) -> pd.DataFrame:
+    """
+    Computes the wall angle, direction, and length for each building in a given GeoPandas GeoSeries.
+
+    This function processes each building's geometry to determine the angles, cardinal directions, 
+    and lengths of its walls. It utilizes parallel processing to enhance performance, especially 
+    with large datasets.
+
+    :param building_geometry: A series containing the geometries of buildings.
+    :type building_geometry: pd.Series
+
+    :param n_jobs: The number of CPU cores to use for parallel processing. Defaults to -1, which 
+                   uses all available cores. If set to a value less than 1, it defaults to 1 core.
+    :type n_jobs: int
+
+    :return: A DataFrame where each row corresponds to a building and contains lists of wall angles, 
+             directions, and lengths.
+    :rtype: pd.DataFrame
+
+    :raises TypeError: If the input is not a GeoPandas GeoSeries or cannot be converted to one.
+    """
+    if not isinstance(building_geometry, gpd.GeoSeries):
+        try:
+            building_geometry = gpd.GeoSeries(building_geometry)
+        except Exception as e:
+            raise TypeError(f"Input must be a GeoPandas GeoSeries or convertible. Error: {e}")
+
+    # Determine the actual number of cores to use
+    if n_jobs == -1:
+        num_cores = multiprocessing.cpu_count()
+    elif n_jobs < 1:
+         num_cores = 1 # Ensure at least 1 core
+    else:
+         num_cores = min(n_jobs, multiprocessing.cpu_count()) # Don't exceed available cores
+
+    print(f"Starting parallel processing using {num_cores} cores...")
+
+    # Use joblib.Parallel to process geometries
+    # delayed() wraps the function and its arguments for parallel execution
+    results_list = Parallel(n_jobs=num_cores)(
+        delayed(_process_single_geometry)(geom) for geom in building_geometry
     )
 
-    for building in range(building_geometry.size):
-        points_in_polygon = building_geometry.values[building].exterior.xy
+    print("Parallel processing finished.")
 
-        for index, item in enumerate(zip(points_in_polygon[0], points_in_polygon[1])):
-            x, y = item
+    # Create the final DataFrame from the list of dictionaries
+    output_df = pd.DataFrame(results_list, index=building_geometry.index)
 
-            # Store the first set of coordinates.
-            if index == 0:
-                x1, y1 = x, y
-
-            else:
-                x2, y2 = x, y
-
-                wall_angle[building].append(np.degrees(np.arctan2(y2 - y1, x2 - x1)))
-
-                # For each direction, the start degree (from counterclockwise) is included (<=) and the end degree is not included (<).
-                if (
-                    Settings.NORTHEAST_DEGREES
-                    <= wall_angle[building][index - 1]
-                    < Settings.NORTHWEST_DEGREES
-                ):
-                    wall_direction[building].append(Settings.WEST)
-                elif (
-                    Settings.SOUTHEAST_DEGREES_ARCTAN
-                    <= wall_angle[building][index - 1]
-                    < Settings.NORTHEAST_DEGREES
-                ):
-                    wall_direction[building].append(Settings.NORTH)
-                elif (
-                    Settings.SOUTHWEST_DEGREES_ARCTAN
-                    <= wall_angle[building][index - 1]
-                    < Settings.SOUTHEAST_DEGREES_ARCTAN
-                ):
-                    wall_direction[building].append(Settings.EAST)
-                else:
-                    wall_direction[building].append(Settings.SOUTH)
-
-                wall_length[building].append(np.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2))
-
-                # Reset start coordinates.
-                x1, y1 = x, y
-
-    return pd.concat(
-        [
-            pd.Series(wall_angle, name=Settings.WALL_ANGLE),
-            pd.Series(wall_direction, name=Settings.WALL_DIRECTION),
-            pd.Series(wall_length, name=Settings.WALL_LENGTH),
-        ],
-        axis=1,
-    )
+    return output_df
 
 
 def wall_length(wall_angle_direction_length: pd.DataFrame) -> pd.DataFrame:

--- a/naturf/nodes.py
+++ b/naturf/nodes.py
@@ -533,58 +533,62 @@ def frontal_area_index(frontal_area: pd.DataFrame, total_plan_area: pd.Series) -
 def frontal_length(
     buildings_intersecting_plan_area: gpd.GeoDataFrame,
 ) -> pd.DataFrame:
-    """Calculate the frontal length for each cardinal direction from the GeoDataFrame of buildings intersecting the plan area.
-    `buildings_intersecting_plan_area()` needs to include `wall_length`.
+    """
+    Calculate the total frontal length for each cardinal direction per target building
+    using optimized pandas groupby aggregation.
 
-    :param buildings_intersecting_plan_area:    Geometry field for the neighboring buildings from the spatially
-                                                joined data.
-    :type buildings_intersecting_plan_area:     gpd.GeoDataFrame
+    Requires input GeoDataFrame to have columns like 'wall_length_north_neighbor', etc.,
+    and a column specified by Settings.TARGET_ID_FIELD.
 
-    :return:                                    The frontal area for each cardinal direction for each unique building in the
-                                                `buildings_intersecting_plan_area` GeoDataFrame.
-
+    :param buildings_intersecting_plan_area: GeoDataFrame with target building IDs
+                                             and neighbor wall lengths per direction.
+    :type buildings_intersecting_plan_area:  gpd.GeoDataFrame
+    :return:                                 DataFrame indexed by target_building_id
+                                             with total frontal lengths per direction.
+    :rtype:                                  pd.DataFrame
     """
 
-    number_target_buildings = len(buildings_intersecting_plan_area.building_id_target.unique())
-    frontal_length_north, frontal_length_east, frontal_length_south, frontal_length_west = (
-        [0] * number_target_buildings,
-        [0] * number_target_buildings,
-        [0] * number_target_buildings,
-        [0] * number_target_buildings,
-    )
-    index = 0
+    # Construct the specific column names required based on Settings
+    col_north = f"{Settings.WALL_LENGTH_NORTH}_{Settings.NEIGHBOR}"
+    col_east = f"{Settings.WALL_LENGTH_EAST}_{Settings.NEIGHBOR}"
+    col_south = f"{Settings.WALL_LENGTH_SOUTH}_{Settings.NEIGHBOR}"
+    col_west = f"{Settings.WALL_LENGTH_WEST}_{Settings.NEIGHBOR}"
+    grouping_col = Settings.TARGET_ID_FIELD
 
-    for target_building_id in np.sort(buildings_intersecting_plan_area.building_id_target.unique()):
-        # Get DataFrame with any building that intersects the target_building_id plan area.
-        target_building_gdf = buildings_intersecting_plan_area.loc[
-            buildings_intersecting_plan_area[Settings.TARGET_ID_FIELD] == target_building_id
-        ].reset_index()
+    # Input validation
+    required_columns = [grouping_col, col_north, col_east, col_south, col_west]
+    missing_cols = [col for col in required_columns if col not in buildings_intersecting_plan_area.columns]
+    if missing_cols:
+        raise ValueError(f"Missing required columns in input GeoDataFrame: {', '.join(missing_cols)}")
 
-        # Sum frontal length for each cardinal direction
-        frontal_length_north[index] = target_building_gdf[
-            f"{Settings.WALL_LENGTH_NORTH}_{Settings.NEIGHBOR}"
-        ].sum()
-        frontal_length_east[index] = target_building_gdf[
-            f"{Settings.WALL_LENGTH_EAST}_{Settings.NEIGHBOR}"
-        ].sum()
-        frontal_length_south[index] = target_building_gdf[
-            f"{Settings.WALL_LENGTH_SOUTH}_{Settings.NEIGHBOR}"
-        ].sum()
-        frontal_length_west[index] = target_building_gdf[
-            f"{Settings.WALL_LENGTH_WEST}_{Settings.NEIGHBOR}"
-        ].sum()
+    # Define the aggregation operations
+    # We want to sum each of the directional wall length columns
+    aggregations = {
+        col_north: 'sum',
+        col_east: 'sum',
+        col_south: 'sum',
+        col_west: 'sum'
+    }
 
-        index += 1
+    # Perform the groupby and aggregation
+    # Group by the target building ID, then apply the sum aggregation
+    frontal_lengths_grouped = buildings_intersecting_plan_area.groupby(
+        grouping_col
+    ).agg(aggregations)
 
-    return pd.concat(
-        [
-            pd.Series(frontal_length_north, name=Settings.FRONTAL_LENGTH_NORTH),
-            pd.Series(frontal_length_east, name=Settings.FRONTAL_LENGTH_EAST),
-            pd.Series(frontal_length_south, name=Settings.FRONTAL_LENGTH_SOUTH),
-            pd.Series(frontal_length_west, name=Settings.FRONTAL_LENGTH_WEST),
-        ],
-        axis=1,
-    )
+    # Rename the resulting columns to the final desired names
+    rename_map = {
+        col_north: Settings.FRONTAL_LENGTH_NORTH,
+        col_east: Settings.FRONTAL_LENGTH_EAST,
+        col_south: Settings.FRONTAL_LENGTH_SOUTH,
+        col_west: Settings.FRONTAL_LENGTH_WEST,
+    }
+    frontal_lengths_final = frontal_lengths_grouped.rename(columns=rename_map)
+
+    # drop index
+    frontal_lengths_final.reset_index(inplace=True, drop=True)
+
+    return frontal_lengths_final
 
 
 def grimmond_oke_displacement_height(building_height: pd.Series) -> pd.Series:
@@ -1106,19 +1110,25 @@ def _get_polygon_segment_properties(polygon: Polygon) -> tuple[list, list, list]
     """
     angles, directions, lengths = [], [], []
     coords = list(polygon.exterior.coords)
-    if len(coords) < 2: return angles, directions, lengths
+
+    if len(coords) < 2: 
+        return angles, directions, lengths
+
     for i in range(len(coords) - 1):
+
         x1, y1 = coords[i]; x2, y2 = coords[i+1]
         if x1 == x2 and y1 == y2: continue
         angle_rad = np.arctan2(y2 - y1, x2 - x1)
         angle_deg = np.degrees(angle_rad)
         length = np.sqrt((x2 - x1)**2 + (y2 - y1)**2)
-        # Determine direction based on Settings
+
+        # Determine direction
         if Settings.NORTHEAST_DEGREES <= angle_deg < Settings.NORTHWEST_DEGREES: direction = Settings.WEST
         elif Settings.SOUTHEAST_DEGREES_ARCTAN <= angle_deg < Settings.NORTHEAST_DEGREES: direction = Settings.NORTH
         elif Settings.SOUTHWEST_DEGREES_ARCTAN <= angle_deg < Settings.SOUTHEAST_DEGREES_ARCTAN: direction = Settings.EAST
         else: direction = Settings.SOUTH
         angles.append(angle_deg); directions.append(direction); lengths.append(length)
+
     return angles, directions, lengths
 
 
@@ -1161,9 +1171,7 @@ def _process_single_geometry(geom: BaseGeometry | None) -> dict:
                 building_angles.extend(angles)
                 building_directions.extend(directions)
                 building_lengths.extend(lengths)
-    # else: handle other types if necessary, currently ignored
 
-    # Return the dictionary of results for this geometry
     return {
         Settings.WALL_ANGLE: building_angles,
         Settings.WALL_DIRECTION: building_directions,
@@ -1204,19 +1212,12 @@ def wall_angle_direction_length(building_geometry: pd.Series, n_jobs: int = -1) 
     elif n_jobs < 1:
          num_cores = 1 # Ensure at least 1 core
     else:
-         num_cores = min(n_jobs, multiprocessing.cpu_count()) # Don't exceed available cores
+         num_cores = min(n_jobs, multiprocessing.cpu_count())
 
-    print(f"Starting parallel processing using {num_cores} cores...")
-
-    # Use joblib.Parallel to process geometries
-    # delayed() wraps the function and its arguments for parallel execution
     results_list = Parallel(n_jobs=num_cores)(
         delayed(_process_single_geometry)(geom) for geom in building_geometry
     )
 
-    print("Parallel processing finished.")
-
-    # Create the final DataFrame from the list of dictionaries
     output_df = pd.DataFrame(results_list, index=building_geometry.index)
 
     return output_df

--- a/naturf/nodes.py
+++ b/naturf/nodes.py
@@ -192,58 +192,55 @@ def buildings_intersecting_plan_area(
 @log_execution_time
 def building_plan_area(
     buildings_intersecting_plan_area: gpd.GeoDataFrame,
-    join_predicate: str = "intersection",
-    join_rsuffix: str = Settings.NEIGHBOR,
 ) -> pd.Series:
-    """Calculate the building plan area from the GeoDataFrame of buildings intersecting the plan area.
+    """
+    Optimized calculation of building plan area using row-wise intersection
+    and groupby sum.
 
-    :param buildings_intersecting_plan_area:    Geometry field for the neighboring buildings from the spatially
-                                                joined data.
-    :type buildings_intersecting_plan_area:     gpd.GeoDataFrame
+    Calculates the total area of intersection between each target's buffered
+    geometry and all its associated neighbors' original geometries.
 
-    :param join_predicate:                      Selected topology of join.
-                                                DEFAULT: `intersection`
-    :type join_predicate:                       str
-
-    :param join_rsuffix:                        Suffix of the right object in the join.
-                                                DEFAULT: `neighbor`
-    :type join_rsuffix:                         str
-
-    :return:                                    The building plan area for each unique building in the
-                                                `buildings_intersecting_plan_area` GeoDataFrame.
-
+    :param buildings_intersecting_plan_area: GeoDataFrame resulting from sjoin,
+                                             containing target IDs ('building_id_target'),
+                                             target buffered geometry ('building_buffered_target'),
+                                             and neighbor geometry ('building_geometry_neighbor')
+                                             per intersection pair.
+    :type buildings_intersecting_plan_area:  gpd.GeoDataFrame
+    :return:                                 Series indexed by 'building_id_target',
+                                             containing the total summed intersection area.
+    :rtype:                                  pd.Series
     """
 
-    building_plan_area = []
-    index = 0
+    # Define column names
+    target_id_col = "building_id_target"
+    target_buffer_col = "building_buffered_target"
+    neighbor_geom_col = "building_geometry_neighbor"
+    area_col = 'intersection_area' # temporary column for calculated area
 
-    for target_building_id in np.sort(buildings_intersecting_plan_area.building_id_target.unique()):
-        # Get DataFrame with any building that intersects the target_building_id plan area.
-        target_building_gdf = buildings_intersecting_plan_area.loc[
-            buildings_intersecting_plan_area[Settings.TARGET_ID_FIELD] == target_building_id
-        ].reset_index()
+    # Input validation
+    required_columns = [target_id_col, target_buffer_col, neighbor_geom_col]
+    missing_cols = [col for col in required_columns if col not in buildings_intersecting_plan_area.columns]
+    if missing_cols:
+        raise ValueError(f"Missing required columns: {', '.join(missing_cols)}")
+        
+    if not hasattr(buildings_intersecting_plan_area[target_buffer_col], 'geom_type') or \
+       not hasattr(buildings_intersecting_plan_area[neighbor_geom_col], 'geom_type'):
+        raise TypeError(f"Columns '{target_buffer_col}' or '{neighbor_geom_col}' not GeoSeries.")
 
-        # Create GeoDataFrames with building and neighbor info.
-        target_gdf = (
-            target_building_gdf[[Settings.TARGET_ID_FIELD, Settings.TARGET_BUFFERED_FIELD]]
-            .set_geometry(Settings.TARGET_BUFFERED_FIELD)
-            .drop_duplicates()
-        )
-        neighbor_gdf = target_building_gdf[
-            [f"index_{join_rsuffix}", Settings.NEIGHBOR_GEOMETRY_FIELD]
-        ].set_geometry(Settings.NEIGHBOR_GEOMETRY_FIELD)
+    # Work on a copy or directly on the input depending on whether modification is okay
+    gdf = buildings_intersecting_plan_area # Use directly for efficiency if input not needed later
 
-        # Create a new GeoDataFrame with the area of intersection.
-        intersection_gdf = gpd.overlay(
-            target_gdf, neighbor_gdf, how=join_predicate, keep_geom_type=False
-        )
+    # Calculate intersection geometry for each row
+    intersection_geoms = gdf[target_buffer_col].intersection(gdf[neighbor_geom_col])
 
-        # Sum up the area of intersection and add to the output list.
-        building_plan_area.append(intersection_gdf[Settings.DATA_GEOMETRY_FIELD_NAME].area.sum())
+    # Calculate area of each intersection
+    # Assign area directly. Empty or invalid intersections yield area 0.0.
+    gdf[area_col] = intersection_geoms.area
 
-        index += 1
+    # Group by target building ID and sum areas
+    total_plan_area_series = gdf.groupby(target_id_col)[area_col].sum()
 
-    return pd.Series(building_plan_area)
+    return total_plan_area_series
 
 
 @log_execution_time

--- a/naturf/output.py
+++ b/naturf/output.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import geopandas as gpd
 import numpy as np
@@ -182,29 +183,54 @@ def merge_parameters(
 
 @log_execution_time
 def numpy_to_binary(raster_to_numpy: np.ndarray) -> bytes:
-    """Turn the master numpy array containing all 132 aggregated parameters into a binary stream.
-
-    :param raster_to_numpy:         132 level numpy array with each level being an aggregated parameter.
-    :type raster_to_numpy:          np.ndarray
-
-    :return:                        Binary object containing the parameter data.
     """
+    Optimized conversion of a NumPy array to a binary string of packed big-endian integers.
 
-    master_out = []
+    This version uses NumPy's vectorized `astype` and `tobytes` methods for efficiency.
 
-    for i in range(len(raster_to_numpy)):
-        master_outi = bytes()
-        for j in range(len(raster_to_numpy[i])):
-            for k in range(len(raster_to_numpy[i][j])):
-                master_outi += struct.pack(">i", int(raster_to_numpy[i][j][k]))
-        master_out.append(master_outi)
+    :param raster_to_numpy: Input NumPy array (presumably 3D).
+                            Assumes numeric values that can be represented as int32.
+                            Floats will be truncated towards zero. NaNs will cause an error.
+    :type raster_to_numpy:  np.ndarray
+    :return:                Binary string containing packed data in C-contiguous order.
+    :rtype:                 bytes
+    :raises TypeError:      If input is not a NumPy array.
+    :raises ValueError:     If input contains NaN or values incompatible with int32 conversion.
+    """
+    if not isinstance(raster_to_numpy, np.ndarray):
+        raise TypeError("Input must be a NumPy array.")
 
-    master_out_final = bytes()
+    try:
+        # 1. Define the target NumPy dtype (Big-endian 4-byte signed integer)
+        #    '>' for big-endian, 'i4' for 4-byte signed integer.
+        target_dtype = np.dtype('>i4')
 
-    for i in range(len(master_out)):
-        master_out_final += master_out[i]
+        # 2. Convert the array to the target dtype.
+        #    - This handles the int() conversion and endianness simultaneously.
+        #    - WARNING: If raster_to_numpy contains NaNs, this will raise a ValueError.
+        #      Handle NaNs beforehand if necessary (e.g., using np.nan_to_num(raster_to_numpy, nan=0)
+        #      to replace NaNs with 0 before converting to int).
+        #    - WARNING: If values exceed the range of int32, they will wrap around (standard C behavior).
+        #      Consider using np.clip if you need to limit values before conversion.
+        logger.debug(f"Converting array of shape {raster_to_numpy.shape} and dtype {raster_to_numpy.dtype} to {target_dtype}...")
+        packed_array = raster_to_numpy.astype(target_dtype)
 
-    return master_out_final
+        # 3. Get the bytes directly from the array's data buffer.
+        #    '.tobytes()' is highly efficient. It defaults to C-order flattening.
+        logger.debug("Exporting array data to bytes...")
+        binary_data = packed_array.tobytes()
+
+        return binary_data
+
+    except ValueError as e:
+        logger.error(f"ValueError during dtype conversion. Input might contain NaN or incompatible values: {e}", exc_info=True)
+        raise
+
+    except Exception as e:
+        logger.error(f"An unexpected error occurred during NumPy to binary conversion: {e}", exc_info=True)
+        raise 
+
+
 
 
 @log_execution_time
@@ -322,7 +348,11 @@ def write_index(
 
 
 @log_execution_time
-def write_binary(numpy_to_binary: bytes, raster_to_numpy: np.ndarray) -> None:
+def write_binary(
+    numpy_to_binary: bytes, 
+    raster_to_numpy: np.ndarray,
+    binary_output_directory: str = ""
+) -> None:
     """Write the binary file that will be input to WRF.
 
     :param numpy_to_binary:                 Binary object containing the parameter data.
@@ -330,8 +360,10 @@ def write_binary(numpy_to_binary: bytes, raster_to_numpy: np.ndarray) -> None:
 
     :param raster_to_numpy:                 132 level numpy array with each level being an aggregated parameter.
     :type raster_to_numpy:                  np.ndarray
-    """
 
+    :param binary_output_directory:         Full path to the directory to write the binary file to.
+    :type binary_output_directory:          str
+    """
     rows = raster_to_numpy.shape[1]
     cols = raster_to_numpy.shape[2]
 
@@ -345,6 +377,8 @@ def write_binary(numpy_to_binary: bytes, raster_to_numpy: np.ndarray) -> None:
         first_x_index + "-" + second_x_index + "." + first_y_index + "-" + second_y_index
     )
 
-    with open(out_binary_name, "wb") as tile:
+    out_binary_path = os.path.join(binary_output_directory, out_binary_name)
+
+    with open(out_binary_path, "wb") as tile:
         tile.write(numpy_to_binary)
         tile.close()

--- a/naturf/output.py
+++ b/naturf/output.py
@@ -1,3 +1,5 @@
+import logging
+
 import geopandas as gpd
 import numpy as np
 import pandas as pd
@@ -11,8 +13,14 @@ from geocube.api.core import make_geocube
 from geocube.rasterize import rasterize_image
 
 from .config import Settings
+from .utils import log_execution_time
 
 
+# Get a logger for this module (can be used for warnings)
+logger = logging.getLogger(__name__)
+
+
+@log_execution_time
 def aggregate_rasters(rasterize_parameters: xr.Dataset) -> xr.Dataset:
     """Divide each raster by the number of buildings in the cell to get the average parameter value for each cell.
 
@@ -25,6 +33,7 @@ def aggregate_rasters(rasterize_parameters: xr.Dataset) -> xr.Dataset:
     return (rasterize_parameters / rasterize_parameters["building_count"]).fillna(0)
 
 
+@log_execution_time
 def merge_parameters(
     frontal_area_density: pd.DataFrame,
     plan_area_density: pd.DataFrame,
@@ -171,6 +180,7 @@ def merge_parameters(
     return gdf.to_crs(Settings.OUTPUT_CRS)
 
 
+@log_execution_time
 def numpy_to_binary(raster_to_numpy: np.ndarray) -> bytes:
     """Turn the master numpy array containing all 132 aggregated parameters into a binary stream.
 
@@ -197,6 +207,7 @@ def numpy_to_binary(raster_to_numpy: np.ndarray) -> bytes:
     return master_out_final
 
 
+@log_execution_time
 def raster_to_numpy(aggregate_rasters: xr.Dataset) -> np.ndarray:
     """Stack all 132 rasterized parameters into one numpy array for conversion to a binary file.
 
@@ -219,6 +230,7 @@ def raster_to_numpy(aggregate_rasters: xr.Dataset) -> np.ndarray:
     return master * 10**Settings.SCALING_FACTOR
 
 
+@log_execution_time
 def rasterize_parameters(merge_parameters: gpd.GeoDataFrame) -> xr.Dataset:
     """Rasterize parameters in preparation for conversion to numpy arrays. Raster will be of resolution Settings.DEFAULT_OUTPUT_RESOLUTION
     and each cell will be the sum of each parameter value within. By default all_touched is True so that every building that is within a cell is
@@ -243,6 +255,7 @@ def rasterize_parameters(merge_parameters: gpd.GeoDataFrame) -> xr.Dataset:
     )
 
 
+@log_execution_time
 def write_index(
     raster_to_numpy: np.ndarray,
     building_geometry: pd.Series,
@@ -308,6 +321,7 @@ def write_index(
         )
 
 
+@log_execution_time
 def write_binary(numpy_to_binary: bytes, raster_to_numpy: np.ndarray) -> None:
     """Write the binary file that will be input to WRF.
 

--- a/naturf/output.py
+++ b/naturf/output.py
@@ -5,7 +5,6 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 from pyproj.crs import CRS
-import struct
 import xarray as xr
 
 from functools import partial
@@ -32,8 +31,7 @@ def aggregate_rasters(rasterize_parameters: xr.Dataset) -> xr.Dataset:
     """
 
     return (rasterize_parameters / rasterize_parameters["building_count"]).fillna(0)
-    x = (rasterize_parameters / rasterize_parameters["building_count"]).fillna(0)
-    
+
 
 @log_execution_time
 def merge_parameters(
@@ -204,7 +202,7 @@ def numpy_to_binary(raster_to_numpy: np.ndarray) -> bytes:
     try:
         # 1. Define the target NumPy dtype (Big-endian 4-byte signed integer)
         #    '>' for big-endian, 'i4' for 4-byte signed integer.
-        target_dtype = np.dtype('>i4')
+        target_dtype = np.dtype(">i4")
 
         # 2. Convert the array to the target dtype.
         #    - This handles the int() conversion and endianness simultaneously.
@@ -213,7 +211,9 @@ def numpy_to_binary(raster_to_numpy: np.ndarray) -> bytes:
         #      to replace NaNs with 0 before converting to int).
         #    - WARNING: If values exceed the range of int32, they will wrap around (standard C behavior).
         #      Consider using np.clip if you need to limit values before conversion.
-        logger.debug(f"Converting array of shape {raster_to_numpy.shape} and dtype {raster_to_numpy.dtype} to {target_dtype}...")
+        logger.debug(
+            f"Converting array of shape {raster_to_numpy.shape} and dtype {raster_to_numpy.dtype} to {target_dtype}..."
+        )
         packed_array = raster_to_numpy.astype(target_dtype)
 
         # 3. Get the bytes directly from the array's data buffer.
@@ -224,12 +224,17 @@ def numpy_to_binary(raster_to_numpy: np.ndarray) -> bytes:
         return binary_data
 
     except ValueError as e:
-        logger.error(f"ValueError during dtype conversion. Input might contain NaN or incompatible values: {e}", exc_info=True)
+        logger.error(
+            f"ValueError during dtype conversion. Input might contain NaN or incompatible values: {e}",
+            exc_info=True,
+        )
         raise
 
     except Exception as e:
-        logger.error(f"An unexpected error occurred during NumPy to binary conversion: {e}", exc_info=True)
-        raise 
+        logger.error(
+            f"An unexpected error occurred during NumPy to binary conversion: {e}", exc_info=True
+        )
+        raise
 
 
 @log_execution_time
@@ -348,9 +353,7 @@ def write_index(
 
 @log_execution_time
 def write_binary(
-    numpy_to_binary: bytes, 
-    raster_to_numpy: np.ndarray,
-    binary_output_directory: str = ""
+    numpy_to_binary: bytes, raster_to_numpy: np.ndarray, binary_output_directory: str = ""
 ) -> None:
     """Write the binary file that will be input to WRF.
 

--- a/naturf/output.py
+++ b/naturf/output.py
@@ -231,8 +231,6 @@ def numpy_to_binary(raster_to_numpy: np.ndarray) -> bytes:
         raise 
 
 
-
-
 @log_execution_time
 def raster_to_numpy(aggregate_rasters: xr.Dataset) -> np.ndarray:
     """Stack all 132 rasterized parameters into one numpy array for conversion to a binary file.

--- a/naturf/output.py
+++ b/naturf/output.py
@@ -32,7 +32,8 @@ def aggregate_rasters(rasterize_parameters: xr.Dataset) -> xr.Dataset:
     """
 
     return (rasterize_parameters / rasterize_parameters["building_count"]).fillna(0)
-
+    x = (rasterize_parameters / rasterize_parameters["building_count"]).fillna(0)
+    
 
 @log_execution_time
 def merge_parameters(

--- a/naturf/utils.py
+++ b/naturf/utils.py
@@ -1,0 +1,33 @@
+import time
+import logging
+import functools
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+
+# Get a logger for this utility module
+logger = logging.getLogger(__name__)
+
+
+def log_execution_time(func):
+    """Decorator to log the execution time of a function."""
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        logger.info(f"Entering: {func.__name__}...") # Use logger defined here
+        start_time = time.perf_counter()
+        try:
+            result = func(*args, **kwargs)
+            end_time = time.perf_counter()
+            duration = end_time - start_time
+            logger.info(f"Exiting: {func.__name__} - Duration: {duration:.4f} seconds")
+            return result
+        except Exception as e:
+            end_time = time.perf_counter()
+            duration = end_time - start_time
+            logger.error(f"FAILED: {func.__name__} - Duration: {duration:.4f} seconds - Error: {e}", exc_info=True)
+            raise e
+    return wrapper

--- a/naturf/utils.py
+++ b/naturf/utils.py
@@ -5,8 +5,8 @@ import functools
 
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S'
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
 )
 
 # Get a logger for this utility module
@@ -15,9 +15,10 @@ logger = logging.getLogger(__name__)
 
 def log_execution_time(func):
     """Decorator to log the execution time of a function."""
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        logger.info(f"Entering: {func.__name__}...") # Use logger defined here
+        logger.info(f"Entering: {func.__name__}...")
         start_time = time.perf_counter()
         try:
             result = func(*args, **kwargs)
@@ -28,6 +29,10 @@ def log_execution_time(func):
         except Exception as e:
             end_time = time.perf_counter()
             duration = end_time - start_time
-            logger.error(f"FAILED: {func.__name__} - Duration: {duration:.4f} seconds - Error: {e}", exc_info=True)
+            logger.error(
+                f"FAILED: {func.__name__} - Duration: {duration:.4f} seconds - Error: {e}",
+                exc_info=True,
+            )
             raise e
+
     return wrapper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "naturf"
-version = "1.0.4"
+version = "1.1.0"
 description = 'The Neighborhood Adaptive Tissues for Urban Resilience Futures tool (NATURF) is a Python workflow that generates data readable by the Weather Research and Forecasting (WRF) model. The NATURF Python modules use shapefiles containing building footprint and height data as input to calculate 132 building parameters at any resolution and converts the parameters into a binary file format.'
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -414,7 +414,7 @@ class TestNodes(unittest.TestCase):
         ]
 
         for case in testcases:
-            actual = nodes.building_plan_area(case.input)
+            actual = pd.Series(nodes.building_plan_area(case.input).values)
             expected = pd.Series(case.expected)
             pd.testing.assert_series_equal(
                 expected,


### PR DESCRIPTION
**Purpose**:  

Add support for MultiPolygon geometry and parallelization.  The original code would fail if a MultiPolygon geometry type was present in the data.

**Changes**:

1. Modified `wall_angle_direction_length` function to account for MultiPolygon geometries and to run each building feature in parallel.  

2. Replaced `frontal_length` function containing a slow loop with a groupby agg for speed up.

3. Added a logger wrapper around each function to report out verbose progress updates.

4. Updated version to v1.1.0

5. Speed up `numpy_to_binary` function.  Note:  If values exceed the range of int32, they will wrap around (standard C behavior).

I also added in two helper functions:

- `_get_polygon_segment_properties`:  calculates the angles, directions, and lengths of each segment of a polygon's exterior

- `_process_single_geometry`:  processes a single geometry object to extract wall angles, directions, and lengths


